### PR TITLE
Handle O codes generally

### DIFF
--- a/gcode/parser.go
+++ b/gcode/parser.go
@@ -40,6 +40,9 @@ func ParseStatement(line string) (*Statement, error) {
 	// catching toolchanges with a special regex
 	toolchangeRE := regexp.MustCompile(`^(T)(\d+)`)
 
+	// catching O-codes with a special regex
+	ocodeRE := regexp.MustCompile(`^(O\d+.*)`)
+
 	// this regex says "line starts with a group which is G, M, or T followed by a
 	// positive real,followed by zero or more whitespace,
 	// optionally followed by a group that starts with A-Z.
@@ -62,6 +65,12 @@ func ParseStatement(line string) (*Statement, error) {
 			return nil, fmt.Errorf("unparsable tool number: '%s' %v", tool[2], err)
 		}
 		stmt.params[tool[1]] = float64(toolNum)
+		return stmt, nil
+	}
+
+	// catching O codes and storing the whole statement as the command, not parsing params
+	if ocodeRE.MatchString(code) {
+		stmt.command = code
 		return stmt, nil
 	}
 

--- a/gcode/statement_test.go
+++ b/gcode/statement_test.go
@@ -15,6 +15,8 @@ var testLines = []testLine{
 	{"M0", STOPPING},
 	{"T0", TOOLCHANGE},
 	{"O21 D0014", UNKNOWN},
+	{"O1 Dsometext", UNKNOWN},
+	{"O30 D0 D42ff1e6f", UNKNOWN},
 	{"G4 S0 ; Dwell", NON_MODAL},
 	{"G1  Y142.400", MOTION},
 	{"G1 Z0.40 F10800", MOTION},


### PR DESCRIPTION
They have parameters that can be non-numeric.  For now, not parsing
parameters at all, simply storing the entire statement in stmt.code