### PR TITLE
Handle oddball non-numeric parameters

### DIFF
--- a/gcode/parser.go
+++ b/gcode/parser.go
@@ -46,8 +46,7 @@ func ParseStatement(line string) (*Statement, error) {
 	// this regex says "line starts with a group which is G, M, or T followed by a
 	// positive real,followed by zero or more whitespace,
 	// optionally followed by a group that starts with A-Z.
-	// adding support for capturing O codes
-	commandRE := regexp.MustCompile(`^([GMO][\d.]+)\s*([A-Z].*)?`)
+	commandRE := regexp.MustCompile(`^([GM][\d.]+)\s*([A-Z].*)?`)
 
 	// this regex says "find any group which starts with A-Z followed by zero or more whitespace
 	// followed by an optional - followed by any number of digits or decimal.

--- a/gcode/parser.go
+++ b/gcode/parser.go
@@ -88,7 +88,10 @@ func ParseStatement(line string) (*Statement, error) {
 		number := m[2]
 		value, err := strconv.ParseFloat(number, 64)
 		if err != nil {
-			return nil, fmt.Errorf("bad param! '%s': %s: %v", line, m[0], err)
+			// if we can't parse a param, add it to the code.  This is kinda hacky and may need revision, but it is
+			// needed to catch some goofy edge cases without special casing them all directly
+			stmt.command = fmt.Sprintf("%s %s", stmt.command, m[0])
+			continue
 		}
 		stmt.params[letter] = value
 	}

--- a/gcode/statement_test.go
+++ b/gcode/statement_test.go
@@ -15,6 +15,7 @@ var testLines = []testLine{
 	{"M0", STOPPING},
 	{"T0", TOOLCHANGE},
 	{"O21 D0014", UNKNOWN},
+	{"M115 U3.7.2", UNKNOWN},
 	{"O1 Dsometext", UNKNOWN},
 	{"O30 D0 D42ff1e6f", UNKNOWN},
 	{"G4 S0 ; Dwell", NON_MODAL},


### PR DESCRIPTION
M115 U3.7.1 was the particular line that raised this issue.  As a workaround,
which can be re-addressed in the future if necessary, any parameters that fail
to parse to a numeric are added to the command word.  Rather than parsing to
{"M115", {U="3.7.1"{}, it parses to {"M115 U3.7.1", {}}